### PR TITLE
Fix for Issue 8 - script crashes if apt-check is not present on Ubuntu

### DIFF
--- a/marketplace_validation/img_check.sh
+++ b/marketplace_validation/img_check.sh
@@ -321,6 +321,12 @@ function checkUpdates {
     if [[ $OS == "Ubuntu" ]]; then
         echo -en "\nUpdating apt package database to check for security updates, this may take a minute...\n\n"
         apt-get -y update > /dev/null
+        if [ -f /usr/lib/update-notifier/apt-check ]; then
+          update_count=$(/usr/lib/update-notifier/apt-check 2>&1 | cut -d ';' -f 2)  
+        else
+          echo "ERROR: apt-check binary was not found. Unable to ensure security updates have been installed.  Exiting.";
+          exit 1
+        fi
         update_count=$(/usr/lib/update-notifier/apt-check 2>&1 | cut -d ';' -f 2)
         if [[ $update_count -gt 0 ]]; then
             echo -en "\e[41m[FAIL]\e[0m There are ${update_count} security updates available for this image that have not been installed.\n"


### PR DESCRIPTION
apt-check should always be present on snapshot created images using a supported version of Ubuntu.  This is an edge case unless we are hitting this at times we should not.

A new check and error message has been added but the script will still exit if apt-check is not found since it will not be able to detect if security updates are needed.