### PR TITLE
add apt-get update/upgrade to cleanup, fix typo

### DIFF
--- a/marketplace_docs/template/fabfile.py
+++ b/marketplace_docs/template/fabfile.py
@@ -14,6 +14,8 @@ def clean_up():
     """
     Clean up remote machine before taking snapshot.
     """
+    run("apt-get -y update")
+    run("apt-get -y upgrade")
     run("rm -rf /tmp/* /var/tmp/*")
     run("history -c")
     run("cat /dev/null > /root/.bash_history")

--- a/marketplace_docs/template/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/marketplace_docs/template/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Scripts in this directory will be executed by cloud-init on the first boot of droplets
-# created from your image.  Things ike generating passwords, configuration requiring IP address
+# created from your image.  Things like generating passwords, configuration requiring IP address
 # or other items that will be unique to each instance should be done in scripts here.


### PR DESCRIPTION
I noticed [the docs](https://github.com/digitalocean/marketplace-partners/blob/master/marketplace_docs/build-an-image.md#cleaning-up-your-build-droplet) suggest `apt-get update/upgrade` as part of the cleanup, but it wasn't part of the template. This was causing my img_check to fail since packages were not all updated.

Also fixed a typo.