### PR TITLE
Changed apt-get to apt

### DIFF
--- a/marketplace_docs/build-an-image.md
+++ b/marketplace_docs/build-an-image.md
@@ -73,8 +73,8 @@ To ensure that your build droplet results in a clean image you can run the follo
 
 ```
 #!/bin/bash
-apt-get -y update
-apt-get -y upgrade
+apt -y update
+apt -y upgrade
 rm -rf /tmp/* /var/tmp/*
 history -c
 cat /dev/null > /root/.bash_history


### PR DESCRIPTION
Updated clean-up script to use apt instead of apt-get.
apt is the newer tool and it works better than simple apt-get. If apt-get is used, not all security patches get installed and img_check.sh will fail. Note that apt-get can also be used, but is has to be enhanced with additional flags like  --with-new-pkgs and etc. I think apt is the more appropriate solution.