### PR TITLE
Update Mongo to the last non-sspl release

### DIFF
--- a/marketplace_validation/img_check.sh
+++ b/marketplace_validation/img_check.sh
@@ -431,7 +431,7 @@ function checkMongoDB {
 
      if [[ -f "/usr/bin/mongod" ]]; then
        version=$(/usr/bin/mongod --version --quiet | grep "db version" | sed -e "s/^db\ version\ v//")
-       if [[ $version > "3.6.8" ]]; then
+       if [[ $version > "4.0.3" ]]; then
          echo -en "\e[41m[FAIL]\e[0m An SSPL version of MongoDB is present"
          ((FAIL++))
           STATUS=2
@@ -448,7 +448,7 @@ function checkMongoDB {
 
     if [[ -f "/usr/bin/mongod" ]]; then
        version=$(/usr/bin/mongod --version --quiet | grep "db version" | sed -e "s/^db\ version\ v//")
-       if [[ $version > "3.6.8" ]]; then
+       if [[ $version > "4.0.3" ]]; then
          echo -en "\e[41m[FAIL]\e[0m An SSPL version of MongoDB is present"
          ((FAIL++))
           STATUS=2


### PR DESCRIPTION
3.6.x was way before SSPL

https://www.mongodb.com/community/licensing

> MongoDB, Inc.’s Server Side Public License (for all versions released after October 16, 2018, including patch fixes for prior versions).

https://docs.mongodb.com/manual/release-notes/4.0/#oct-9-2018

![image](https://user-images.githubusercontent.com/51996/59309276-ccaeb580-8c68-11e9-9481-b2566864684f.png)
