### PR TITLE
fix CSF Firewall check on CentOS 7

### DIFF
--- a/marketplace_validation/img_check.sh
+++ b/marketplace_validation/img_check.sh
@@ -344,7 +344,7 @@ function checkFirewall {
     elif [[ $OS == "CentOS Linux" ]]; then
       if [ -f /usr/lib/systemd/system/csf.service ]; then
         fw="csf"
-        if [[ $(systemctl status $fw >/dev/null 2>&1) ]]; then
+        if [[ $(systemctl status $fw >/dev/null 2>&1; echo $?) -eq '0' ]]; then
           
         FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
         ((PASS++))


### PR DESCRIPTION
The img_check.sh for CentOS + CSF Firewall fails again at https://github.com/digitalocean/marketplace-partners/blob/95f1d13f0294efe3156c8fbb283127ba7f775635/marketplace_validation/img_check.sh#L345-L354 as the systemctl status check reports CSF Firewall as not running when in fact it is

```
    digitalocean: DigitalOcean Marketplace Image Validation Tool v. 1.1
    digitalocean: Executed on: Thu Jun 20 03:22:11 UTC 2019
    digitalocean: Checking local system for Marketplace compatibility...
    digitalocean:
    digitalocean: Distribution: CentOS Linux
    digitalocean: Version: 7
    digitalocean:
    digitalocean: [PASS] Supported Operating System Detected: CentOS Linux
    digitalocean: [PASS] Supported Release Detected: 7
    digitalocean: [PASS] Cloud-init is installed.
    digitalocean: [WARN] No firewall is configured. Ensure csf is installed and configured
    digitalocean:
```

```
        fw="csf"
        if [[ $(systemctl status $fw >/dev/null 2>&1) ]]; then
          
        FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
        ((PASS++))
        else
          FW_VER="\e[93m[WARN]\e[0m No firewall is configured. Ensure ${fw} is installed and configured\n"
        ((WARN++))
        fi
```

simplified version of below returns = no 
```
fw="csf"
        if [[ $(systemctl status $fw >/dev/null 2>&1) ]]; then
          echo yes
       else
         echo no
      fi
```
but csf firewall is running

```
systemctl status $fw
● csf.service - ConfigServer Firewall & Security - csf
   Loaded: loaded (/usr/lib/systemd/system/csf.service; enabled; vendor preset: disabled)
   Active: active (exited) since Wed 2019-06-19 18:02:35 UTC; 9h ago
  Process: 2877 ExecStart=/usr/sbin/csf --initup (code=exited, status=0/SUCCESS)
 Main PID: 2877 (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/csf.service

Jun 19 18:02:33 cmm-centos76-base-img-s-1vcpu-1gb-sfo2-01 systemd[1]: Starting ConfigServer Firewall & Security - csf...
Jun 19 18:02:35 cmm-centos76-base-img-s-1vcpu-1gb-sfo2-01 systemd[1]: Started ConfigServer Firewall & Security - csf.
Jun 19 18:02:35 cmm-centos76-base-img-s-1vcpu-1gb-sfo2-01 csf[2877]: (restoring ipsets) (restoring iptables) (restoring ip6tables)
```

proposed change

```
fw="csf"
       if [[ $(systemctl status $fw >/dev/null 2>&1; echo $?) -eq '0' ]]; then
          echo yes
       else
         echo no
      fi
```

returns yes when evaluated with csf firewall running

so change is from 

```
        fw="csf"
        if [[ $(systemctl status $fw >/dev/null 2>&1) ]]; then
          
        FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
        ((PASS++))
        else
          FW_VER="\e[93m[WARN]\e[0m No firewall is configured. Ensure ${fw} is installed and configured\n"
        ((WARN++))
        fi
```
to
```
        fw="csf"
        if [[ $(systemctl status $fw >/dev/null 2>&1; echo $?) -eq '0' ]]; then
          
        FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
        ((PASS++))
        else
          FW_VER="\e[93m[WARN]\e[0m No firewall is configured. Ensure ${fw} is installed and configured\n"
        ((WARN++))
        fi
```