### PR TITLE
Use apt and wait for cloud-init

### DIFF
--- a/packer/marketplace-image.json
+++ b/packer/marketplace-image.json
@@ -29,6 +29,7 @@
     {
       "type": "shell",
       "inline": [
+        "cloud-init status --wait",
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}"

--- a/packer/marketplace-image.json
+++ b/packer/marketplace-image.json
@@ -29,9 +29,9 @@
     {
       "type": "shell",
       "inline": [
-        "apt-get -qqy update",
-        "apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' upgrade",
-        "apt-get -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}"
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}"
       ]
     },
     {


### PR DESCRIPTION
This PR fixes https://github.com/digitalocean/marketplace-partners/issues/67 by making the following changes:

- Wait for cloud-init to complete before updating/installing packages. Otherwise the package update/upgrade runs in parallel with `cloud-init`, which can lead to funky behavior.
- Switch to using `apt` instead of `apt-get` since it is ["the most recommended interface"](https://debian-handbook.info/browse/stable/sect.apt-get.html)).
- Switch `apt-get upgrade` to `apt full-upgrade`. This will remove some obsolete packages or install new dependencies if required and is the reason `apt-check` reports an inconsistent list of security updates. `full-updates` should be safe to use because no packages have been installed at this point.