### PR TITLE
Add Debian 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ To maintain compatibility with Marketplace tools and processes, we support a lim
 We currently support the following OSes:
 
 - Debian 9 (stretch)
+- Debian 10 (buster)
 - Ubuntu 18.04 (LTS)
 - Ubuntu 16.04 (LTS)
 - CentOS 7.x
-- CentOS 6.x
 
 All supported operating systems are available as base images to build on in the DigitalOcean cloud.
 

--- a/scripts/img_check.sh
+++ b/scripts/img_check.sh
@@ -566,6 +566,9 @@ elif [[ "$OS" =~ Debian.* ]]; then
         9)
             osv=1
             ;;
+        10)
+            osv=1
+            ;;
         *)
             osv=2
             ;;


### PR DESCRIPTION
Adds support for Debian 10 to img_chcek.sh
Adds Debian 10 to list of supported distros in the Readme
Removes CentOS 6 from the list of supported distros in the readme (EOL soon)