### PR TITLE
Only extract the status text from ufw

### DIFF
--- a/scripts/img_check.sh
+++ b/scripts/img_check.sh
@@ -333,7 +333,7 @@ function checkFirewall {
     
     if [[ $OS == "Ubuntu" ]]; then
       fw="ufw"
-      ufwa=$(ufw status | sed -e "s/^Status:\ //")
+      ufwa="$(ufw status | awk '{print $2}' | head -n1)"
       if [[ $ufwa == "active" ]]; then
         FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
         ((PASS++))
@@ -375,7 +375,7 @@ function checkFirewall {
       # we will check some of the most common
       if cmdExists 'ufw'; then
         fw="ufw"
-        ufwa=$(ufw status | sed -e "s/^Status:\ //")
+        ufwa="$(ufw status | awk '{print $2}' | head -n1)"
         if [[ $ufwa == "active" ]]; then
         FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
         ((PASS++))


### PR DESCRIPTION
Took me a bit to realize what was going on here but I think I've got it nailed down.  Let me know if you need any changes or whatever else.

### Problem

The `checkFirewall` test case for UFW being enabled isn't quite right: For example, in the case of adding a few custom rules:

```sh
ufw -f enable
ufw allow 22/tcp
ufw allow 80/tcp
ufw allow 443/tcp
```

[`$ufwa`](https://github.com/digitalocean/marketplace-partners/blob/60aa691dd3c3a7464d1bd8ffe54357968a0302e3/scripts/img_check.sh#L336) evaluates to as:

```sh
root@24642955b914: ufw status | sed -e "s/^Status:\ //"
active

To                         Action      From
--                         ------      ----
22/tcp                     ALLOW       Anywhere
80/tcp                     ALLOW       Anywhere
443/tcp                    ALLOW       Anywhere
22/tcp (v6)                ALLOW       Anywhere (v6)
80/tcp (v6)                ALLOW       Anywhere (v6)
443/tcp (v6)               ALLOW       Anywhere (v6)
```

Which doesn't qualify for the logical assertion:

```sh
if [[ $ufwa == "active" ]]; then
```

### Solution

To keep things as similar as possible, I've changed `ufwa` to:

```sh
root@24642955b914: ufw status | awk '{print $2}' | head -n1
active
```

Allowing the statement to succeed.

- - -

Alternatively, since the `$ufwa` variable isn't really being used, it might make sense to change the entire if conditional to:

```sh
if ufw status | grep 'Status: inactive'`; then
  # ...
fi
```

But ¯\\_(ツ)_/¯ - lmk.
