### PR TITLE
Fix ufw detection on Ubuntu

### DIFF
--- a/scripts/img_check.sh
+++ b/scripts/img_check.sh
@@ -342,8 +342,7 @@ function checkFirewall {
     
     if [[ $OS == "Ubuntu" ]]; then
       fw="ufw"
-      ufwa=$(ufw status | sed -e "s/^Status:\ //")
-      if [[ $ufwa == "active" ]]; then
+      if ufw status | grep -e "^Status: active" > /dev/null;
         FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
         ((PASS++))
       else


### PR DESCRIPTION
The `ufw status` command might print some rules besides the first line with `Status: active`. This checks for a line starting with `Status: active` and ignores the rest of the output instead.