### PR TITLE
cleanup.sh: Zero out revoked_keys file

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -11,6 +11,9 @@ apt-get -y autoclean
 find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
 rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????
 rm -rf /var/lib/cloud/instances/*
-rm -f /root/.ssh/authorized_keys /etc/ssh/*key*
+rm -f /root/.ssh/authorized_keys 
+cd /etc/ssh ; find . -type f ! -name 'revoked_keys' -delete
+touch /etc/ssh/revoked_keys
+chmod 600 /etc/ssh/revoked_keys
 dd if=/dev/zero of=/zerofile; sync; rm /zerofile; sync
 cat /dev/null > /var/log/lastlog; cat /dev/null > /var/log/wtmp


### PR DESCRIPTION
This change to the cleanup script is to address a rare issue where sshd may refuse to allow ssh logins if the revoked_keys file does not exist and is not mode 600.

I realize that this might not be the most elegant solution.

The `find` approach appears to work on OSX so I am confident enough to submit the PR: 

`John-Gannons-MBP:ssh-stuff johngannon$ ls
revoked_keys		some_other_ssh_key	this_ssh_key
John-Gannons-MBP:ssh-stuff johngannon$ 
John-Gannons-MBP:ssh-stuff johngannon$ find . -type f ! -name 'revoked_keys' -delete
John-Gannons-MBP:ssh-stuff johngannon$ ls
revoked_keys
`

Thanks to https://unix.stackexchange.com/questions/78376/in-linux-how-to-delete-all-files-except-the-pattern-txt for the inspiration ;)