### PR TITLE
cleanup.sh: revoked_keys ssh bug fix

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -12,5 +12,6 @@ find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
 rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????
 rm -rf /var/lib/cloud/instances/*
 rm -f /root/.ssh/authorized_keys /etc/ssh/*key*
+touch /etc/ssh/revoked_keys
 dd if=/dev/zero of=/zerofile; sync; rm /zerofile; sync
 cat /dev/null > /var/log/lastlog; cat /dev/null > /var/log/wtmp

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -13,5 +13,6 @@ rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????
 rm -rf /var/lib/cloud/instances/*
 rm -f /root/.ssh/authorized_keys /etc/ssh/*key*
 touch /etc/ssh/revoked_keys
+chmod 600 /etc/ssh/revoked_keys
 dd if=/dev/zero of=/zerofile; sync; rm /zerofile; sync
 cat /dev/null > /var/log/lastlog; cat /dev/null > /var/log/wtmp


### PR DESCRIPTION
There's a rare issue that can occur with certain ssh configurations where ssh login using key based auth will be refused: 

- if /etc/ssh/revoked_keys does not exist OR
- if /etc/ssh/revoked_keys has permissions that are not mode 600 

This PR should address that issue by ensuring the revoked_keys file exists, is zero bytes, and has mode 600 set. 