### PR TITLE
README.md: copy edits re: automated builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ The overall process for creating a Marketplace image is as follows:
 
 2. **Clean up and validate the build Droplet with the provided scripts**, `cleanup.sh` and `img_check.sh`. The scripts will check for and fix potential security concerns and verify that the image will be compatible with Marketplace.
 
-3. **Take a [snapshot](https://www.digitalocean.com/docs/images/snapshots/) of the build Droplet** after you power it down, then test the resulting image. While there are several ways to create an image, we recommend snapshots as the most simple and consistent option.
+3. **Take a [snapshot](https://www.digitalocean.com/docs/images/snapshots/) of the build Droplet** after you power it down, then test the resulting image. While there are several ways to create an image, we recommend snapshots as the most simple and consistent option. 
 
-4. **Automate your build** for replicable and configurable processes with minimal additional effort. We provide some Fabric and Packer templates to get you started.
-
-5. **Submit your final image** to the Marketplace team for review.
+4. **Submit your final image** to the Marketplace team for review.
 
 Our [Getting Started documentation](getting-started.md) that includes our image requirements, configuration recommendations, how to run commands on first boot and first login, and details on exactly what our helper scripts do.
 
-We also have a [Fabric template and docs](fabric) and a [Packer template and docs](packer) that you can use as starting points to automate your build system.
+We also have in this repo a [Fabric template and docs](fabric) and a [Packer template and docs](packer) that you can use to automate your build system with minimal additional effort.
 
 ## Supported Operating Systems
 


### PR DESCRIPTION
Moving some text around so that automated build mention and links appears in a more logical place.