### PR TITLE
Issue 60 check for key in log

### DIFF
--- a/scripts/img_check.sh
+++ b/scripts/img_check.sh
@@ -110,12 +110,18 @@ function checkLogs {
       [[ -e $f ]] || break
       if [[ "${f}" = '/var/log/lfd.log' && "$( cat "${f}" | egrep -v '/var/log/messages has been reset| Watching /var/log/messages' | wc -c)" -gt 50 ]]; then
         if [ $f != $cp_ignore ]; then
-        echo -en "\e[93m[WARN]\e[0m un-cleared log file, ${f} found\n"
-        ((WARN++))
-        if [[ $STATUS != 2 ]]; then
-            STATUS=1
+          echo -en "\e[93m[WARN]\e[0m un-cleared log file, ${f} found\n"
+          ((WARN++))
+          if [[ $STATUS != 2 ]]; then
+              STATUS=1
+          fi
         fi
-      fi
+      elif [[ "${f}" == '/var/log/cloud-init-output.log' ]]; then
+        if cat '/var/log/cloud-init-output.log' | grep -q SHA256; then
+          echo -en "\e[41m[FAIL]\e[0m log containing SHA256 value found in log file ${f}\n"
+          ((FAIL++))
+          STATUS=1
+        fi
       elif [[ "${f}" != '/var/log/lfd.log' && "$( cat "${f}" | wc -c)" -gt 50 ]]; then
       if [ $f != $cp_ignore ]; then
         echo -en "\e[93m[WARN]\e[0m un-cleared log file, ${f} found\n"


### PR DESCRIPTION
**BACKGROUND**
https://github.com/digitalocean/marketplace-partners/issues/60

We want to check to make sure that the output log doesn't contain any SHA256 values inside of it and fail if it does.

**CHANGES**
* add a specific check for the `cloud-init-output.log` file and search for the `SHA256` value and fail if it's found.

cc @arosales 