### PR TITLE
Make cleanup.sh run on CentOS

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+
 # Ensure /tmp exists and has the proper permissions before
 # checking for security updates
 # https://github.com/digitalocean/marketplace-partners/issues/94
@@ -8,14 +10,20 @@ if [[ ! -d /tmp ]]; then
 fi
 chmod 1777 /tmp
 
-apt-get -y update
-apt-get -y upgrade
+if [ -n "$(command -v yum)" ]; then
+  yum update -y
+  yum clean all
+elif [ -n "$(command -v apt-get)" ]; then
+  apt-get -y update
+  apt-get -y upgrade
+  apt-get -y autoremove
+  apt-get -y autoclean
+fi
+
 rm -rf /tmp/* /var/tmp/*
 history -c
 cat /dev/null > /root/.bash_history
 unset HISTFILE
-apt-get -y autoremove
-apt-get -y autoclean
 find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
 rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????
 rm -rf /var/lib/cloud/instances/*


### PR DESCRIPTION
Conditionally execute `apt-get` or `yum` commands as appropriate. Add `errexit` option to exit when one command fails.