### PR TITLE
updated exit code for warnings

### DIFF
--- a/scripts/img_check.sh
+++ b/scripts/img_check.sh
@@ -675,7 +675,7 @@ if [[ $STATUS == 0 ]]; then
     exit 0
 elif [[ $STATUS == 1 ]]; then
     echo -en "Please review all [WARN] items above and ensure they are intended or resolved.  If you do not have a specific requirement, we recommend resolving these items before image submission\n\n"
-    exit 1
+    exit 0
 else
     echo -en "Some critical tests failed.  These items must be resolved and this scan re-run before you submit your image to the DigitalOcean Marketplace.\n\n"
     exit 1


### PR DESCRIPTION
Returning an error code on WARNings is a bit misleading. Makes more sense to return a "success" code, or at the very least return a different exit code to differentiate from FAILure cases