### PR TITLE
small improvements

### DIFF
--- a/scripts/90-cleanup.sh
+++ b/scripts/90-cleanup.sh
@@ -27,6 +27,7 @@ fi
 
 rm -rf /tmp/* /var/tmp/*
 history -c
+cat /dev/null > /root/.bash_history
 unset HISTFILE
 find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
 rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????

--- a/scripts/90-cleanup.sh
+++ b/scripts/90-cleanup.sh
@@ -18,15 +18,15 @@ if [ -n "$(command -v yum)" ]; then
   yum update -y
   yum clean all
 elif [ -n "$(command -v apt-get)" ]; then
+	export DEBIAN_FRONTEND=noninteractive
   apt-get -y update
-  apt-get -y upgrade
+	apt-get -o Dpkg::Options::="--force-confold" upgrade -q -y --force-yes
   apt-get -y autoremove
   apt-get -y autoclean
 fi
 
 rm -rf /tmp/* /var/tmp/*
 history -c
-cat /dev/null > /root/.bash_history
 unset HISTFILE
 find /var/log -mtime -1 -type f -exec truncate -s 0 {} \;
 rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-????????
@@ -45,12 +45,4 @@ The secure erase will complete successfully when you see:${NC}
     dd: writing to '/zerofile': No space left on device\n
 Beginning secure erase now\n"
 
-dd if=/dev/zero of=/zerofile &
-  PID=$!
-  while [ -d /proc/$PID ]
-    do
-      printf "."
-      sleep 5
-    done
-sync; rm /zerofile; sync
-cat /dev/null > /var/log/lastlog; cat /dev/null > /var/log/wtmp
+dd if=/dev/zero of=/zerofile bs=4096 || rm /zerofile

--- a/scripts/90-cleanup.sh
+++ b/scripts/90-cleanup.sh
@@ -18,9 +18,9 @@ if [ -n "$(command -v yum)" ]; then
   yum update -y
   yum clean all
 elif [ -n "$(command -v apt-get)" ]; then
-	export DEBIAN_FRONTEND=noninteractive
+  export DEBIAN_FRONTEND=noninteractive
   apt-get -y update
-	apt-get -o Dpkg::Options::="--force-confold" upgrade -q -y --force-yes
+  apt-get -o Dpkg::Options::="--force-confold" upgrade -q -y --force-yes
   apt-get -y autoremove
   apt-get -y autoclean
 fi


### PR DESCRIPTION
This solves two issues

1. `apt-get upgrade` does not reliably upgrade the system. I'm not really confident the incantation I have in this PR covers all cases, but it does cover what I'm trying to do right now. Currently, if you attempt to upgrade digitalocean's Ubuntu 20.04 image using simply `apt-get upgrade`, apt will prompt the user for a decision about what to do about openssh configuration. `--force-yes`, `-y` and other options are not sufficient to suppress it, so I had to pass an option that I'm going to keep the old config

2. The `dd` command is too slow, but it can be sped up substantially if you specify a block size. 4096 is a common choice since it is a typical block size.

I also erased lines that truncated lastlog and wtmp since it looked like that was already being truncated earlier in the script.