### PR TITLE
[MP-3865] add rocky linux and centos stream to supported OSs

### DIFF
--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -73,7 +73,7 @@ function checkAgent {
      echo -en "\e[41m[FAIL]\e[0m DigitalOcean Monitoring Agent detected.\n"
             ((FAIL++))
             STATUS=2
-      if [[ $OS == "CentOS Linux" ]]; then
+      if [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]]; then
         echo "The agent can be removed with 'sudo yum remove do-agent' "
       elif [[ $OS == "Ubuntu" ]]; then
         echo "The agent can be removed with 'sudo apt-get purge do-agent' "
@@ -345,7 +345,7 @@ function checkFirewall {
         FW_VER="\e[93m[WARN]\e[0m No firewall is configured. Ensure ${fw} is installed and configured\n"
         ((WARN++))
       fi
-    elif [[ $OS == "CentOS Linux" ]]; then
+    elif [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]]; then
       if [ -f /usr/lib/systemd/system/csf.service ]; then
         fw="csf"
         if [[ $(systemctl status $fw >/dev/null 2>&1) ]]; then
@@ -442,7 +442,7 @@ function checkUpdates {
         else
             echo -en "\e[32m[PASS]\e[0m There are no pending security updates for this image.\n\n"
         fi
-    elif [[ $OS == "CentOS Linux" ]]; then
+    elif [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]]; then
         echo -en "\nChecking for available security updates, this may take a minute...\n\n"
 
         update_count=$(yum check-update --security --quiet | wc -l)
@@ -508,12 +508,10 @@ function checkMongoDB {
        ((PASS++))
      fi
 
-   elif [[ $OS == "CentOS Linux" ]]; then
+   elif [[ $OS == "CentOS Linux" ]] || [[ $OS == "CentOS Stream" ]] || [[ $OS == "Rocky Linux" ]]; then
 
     if [[ -f "/usr/bin/mongod" ]]; then
        version=$(/usr/bin/mongod --version --quiet | grep "db version" | sed -e "s/^db\ version\ v//")
-
-
        if version_gt $version 4.0.0; then
         if version_gt $version 4.0.3; then
           echo -en "\e[41m[FAIL]\e[0m An SSPL version of MongoDB is present"
@@ -600,6 +598,20 @@ elif [[ $OS == "CentOS Linux" ]]; then
     elif [[ $VER == "7" ]]; then
         osv=1
     elif [[ $VER == "6" ]]; then
+        osv=1
+    else
+        osv=2
+    fi
+elif [[ $OS == "CentOS Stream" ]]; then
+        ost=1
+    if [[ $VER == "8" ]]; then
+        osv=1
+    else
+        osv=2
+    fi
+elif [[ $OS == "Rocky Linux" ]]; then
+        ost=1
+    if [[ $VER =~ "8." ]]; then
         osv=1
     else
         osv=2


### PR DESCRIPTION
**Description**

DO is going to support Rocky linux and Centos stream in August, so img-check should be updated

**What this PR adds** 

Img check is updated to accept these OSs.