### PR TITLE
Add support for ubuntu 22 04

### DIFF
--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -494,8 +494,6 @@ if [[ $OS == "Ubuntu" ]]; then
         ost=1
     if [[ $VER == "22.04" ]] || [[ $VER == "20.04" ]] || [[ $VER == "18.04" ]] || [[ $VER == "16.04" ]]; then
         osv=1
-    else
-        osv=0
     fi
 
 elif [[ "$OS" =~ Debian.* ]]; then

--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -492,11 +492,7 @@ osv=0
 
 if [[ $OS == "Ubuntu" ]]; then
         ost=1
-    if [[ $VER == "20.04" ]]; then
-        osv=1
-    elif [[ $VER == "18.04" ]]; then
-        osv=1
-    elif [[ $VER == "16.04" ]]; then
+    if [[ $VER == "22.04" ]] || [[ $VER == "20.04" ]] || [[ $VER == "18.04" ]] || [[ $VER == "16.04" ]]; then
         osv=1
     else
         osv=0


### PR DESCRIPTION
**Description**
Ubuntu 22.04 is not supported in img-check.sh script (found there - https://github.com/digitalocean/marketplace-partners/issues/150)

**What PR does**
Adds support for Ubuntu 22.04

**Proof**
Before:
<img width="520" alt="Screenshot 2022-05-19 at 18 10 22" src="https://user-images.githubusercontent.com/24397578/169335279-15bd313a-3a3a-4e56-9f79-43389495b15e.png">
After:
<img width="661" alt="Screenshot 2022-05-19 at 18 11 36" src="https://user-images.githubusercontent.com/24397578/169335382-86db2931-874d-4615-8861-1f0fc391dbed.png">
