### PR TITLE
Add Debian 11 (bullseye) support

### DIFF
--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -505,6 +505,9 @@ elif [[ "$OS" =~ Debian.* ]]; then
         10)
             osv=1
             ;;
+        11)
+            osv=1
+            ;;            
         *)
             osv=2
             ;;


### PR DESCRIPTION
Debian 11 is a modern and stable distro. It was released a long time ago, and it works exactly as stable as Debian 10 (buster). 