### PR TITLE
Fix ip_tables check in img-check

### DIFF
--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -399,7 +399,7 @@ function checkFirewall {
       else
         # user could be using vanilla iptables, check if kernel module is loaded
         fw="iptables"
-        if [[ $(lsmod | grep -q '^ip_tables' 2>/dev/null) ]]; then
+        if lsmod | grep -q '^ip_tables' 2>/dev/null; then
           FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
         ((PASS++))
         else


### PR DESCRIPTION
The conditional for ip_tables check fails when ip_tables is present. This change fixes the check.

closes #136 