### PR TITLE
Fix DO agent check in img-check

### DIFF
--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -69,7 +69,7 @@ SHADOW=$(cat /etc/shadow)
 
 function checkAgent {
   # Check for the presence of the do-agent in the filesystem
-  if [ -d /var/opt/digitalocean/do-agent ];then
+  if [ -e /opt/digitalocean/do-agent ];then
      echo -en "\e[41m[FAIL]\e[0m DigitalOcean Monitoring Agent detected.\n"
             ((FAIL++))
             STATUS=2


### PR DESCRIPTION
The DO agent lives in a different location than where the check is looking. Update the conditional to check for existence of do_agent file at correct location.

closes #154