### PR TITLE
Have apt-get wait for a lock rather than erroring

### DIFF
--- a/scripts/90-cleanup.sh
+++ b/scripts/90-cleanup.sh
@@ -19,10 +19,10 @@ if [ -n "$(command -v yum)" ]; then
   yum clean all
 elif [ -n "$(command -v apt-get)" ]; then
   export DEBIAN_FRONTEND=noninteractive
-  apt-get -y update
-  apt-get -o Dpkg::Options::="--force-confold" upgrade -q -y --force-yes
-  apt-get -y autoremove
-  apt-get -y autoclean
+  apt-get -o DPkg::Lock::Timeout=3 -y update
+  apt-get -o DPkg::Lock::Timeout=3 -o Dpkg::Options::="--force-confold" upgrade -q -y --force-yes
+  apt-get -o DPkg::Lock::Timeout=3 -y autoremove
+  apt-get -o DPkg::Lock::Timeout=3 -y autoclean
 fi
 
 rm -rf /tmp/* /var/tmp/*


### PR DESCRIPTION
Per the suggestion in this article (https://blog.sinjakli.co.uk/2021/10/25/waiting-for-apt-locks-without-the-hacky-bash-scripts/), this setting tells apt-get to wait for the package lock. Our packer builds have been breaking because this script is conflicting with some internal ubuntu update process which is also using apt-get. We recently updated all out internal scripts to use this setting, and we were able to get around the issue. However, this digitalocean provided script is still erroring. 
```
==> digitalocean.lotus: + bash
==> digitalocean.lotus: + curl -L https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/90-cleanup.sh
==> digitalocean.lotus:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
==> digitalocean.lotus:                                  Dload  Upload   Total   Spent    Left  Speed
==> digitalocean.lotus: 100  1506  100  1506    0     0   8140      0 --:--:-- --:--:-- --:--:--  8140
    digitalocean.lotus: Reading package lists...
==> digitalocean.lotus: E: Could not get lock /var/lib/apt/lists/lock. It is held by process 2770 (apt-get)
==> digitalocean.lotus: E: Unable to lock directory /var/lib/apt/lists/
==> digitalocean.lotus: Provisioning step had errors: Running the cleanup provisioner, if present...
==> digitalocean.lotus: Destroying droplet...
==> digitalocean.lotus: Deleting temporary ssh key...
Build 'digitalocean.lotus' errored after 2 minutes 10 seconds: Script exited with non-zero exit status: 100. Allowed exit codes are: [0]
```

According to that article, the two options are either:
1. Set the `DPkg::Lock::Timeout` value to a reasonable timeout.
2. Use `apt`, which automatically sets this value. However, `apt` comes with the following warning: `WARNING : apt does not have a stable CLI interface. Use with caution in scripts.`

The former seemed more robust, so it's what we used, and what I would recommend using here.
