### PR TITLE
chore: remove unused function

### DIFF
--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -488,9 +488,6 @@ function checkCloudInit {
     return 1
 }
 
-function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
-
-
 clear
 echo "DigitalOcean Marketplace Image Validation Tool ${VERSION}"
 echo "Executed on: ${RUNDATE}"


### PR DESCRIPTION
This causes shellcheck errors since it is unused.