### PR TITLE
Add CentOS Stream 9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ We currently support the following OSes:
 - Ubuntu 18.04 (LTS)
 - Ubuntu 16.04 (LTS)
 - CentOS 7.x
+- CentOS 8.x
+- CentOS Stream 8
+- CentOS Stream 9
 - AlmaLinux 8.x
 - AlmaLinux 9.x
 

--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -542,6 +542,8 @@ elif [[ $OS == "CentOS Stream" ]]; then
         ost=1
     if [[ $VER == "8" ]]; then
         osv=1
+    elif [[ $VER == "9" ]]; then
+        osv=1
     else
         osv=2
     fi


### PR DESCRIPTION
CentOS Stream 9 image is already available on the market, but it not supported by img_check.sh still.