### PR TITLE
Add support for Rocky linux 9.x to img_check

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ We currently support the following OSes:
 - CentOS Stream 9
 - AlmaLinux 8.x
 - AlmaLinux 9.x
+- Rocky Linux 8.x
+- Rocky Linux 9.x
 
 All supported operating systems are available as base images to build on in the DigitalOcean cloud.
 

--- a/scripts/99-img-check.sh
+++ b/scripts/99-img-check.sh
@@ -549,7 +549,7 @@ elif [[ $OS == "CentOS Stream" ]]; then
     fi
 elif [[ $OS == "Rocky Linux" ]]; then
         ost=1
-    if [[ $VER =~ 8\. ]]; then
+    if [[ $VER =~ 8\. ]] || [[ $VER =~ 9\. ]]; then
         osv=1
     else
         osv=2


### PR DESCRIPTION
Our customers ask to add support for Rocky Linux 9.x. This PR allows to use this OS.