### PR TITLE
Disable Droplet Agent install by default

### DIFF
--- a/marketplace-image.json
+++ b/marketplace-image.json
@@ -15,7 +15,8 @@
       "region": "nyc3",
       "size": "s-1vcpu-1gb",
       "ssh_username": "root",
-      "snapshot_name": "{{user `image_name`}}"
+      "snapshot_name": "{{user `image_name`}}",
+      "droplet_agent": false
     }
   ],
   "provisioners": [


### PR DESCRIPTION
This prevents the Droplet Agent from being installed when running a Marketplace Image build.

Fixes #166 